### PR TITLE
Use sparql instead of rdql, one obscure query language is enuf thanx

### DIFF
--- a/cc/license/_lib/functions.py
+++ b/cc/license/_lib/functions.py
@@ -311,10 +311,10 @@ def get_selector_jurisdictions(selector_name='standard'):
 
     selector = cc.license.selectors.choose(selector_name)
     qstring = "\n".join(
-        ["SELECT ?license",
-         "WHERE (?license cc:licenseClass <%s>)" % str(selector.uri),
-         "USING cc FOR <http://creativecommons.org/ns#>"])
-    query = RDF.Query(qstring, query_language="rdql")
+        ["PREFIX cc: <http://creativecommons.org/ns#>",
+         "SELECT ?license",
+         "WHERE {?license cc:licenseClass <%s>}" % str(selector.uri)])
+    query = RDF.Query(qstring, query_language="sparql")
 
     # This is so stupid, but if we add a WHERE clause for
     # jurisdictions in the query string it takes approximately 5


### PR DESCRIPTION
rdql was used in one query but apparently no longer
supported... transformed into SPARQL instead.

mattl told me he wouldn't accept this unless I included this in my
commit message... apologies in advance.

```
       *          *
  *    _  ///\\\          *
      ( \ \\~_~|    Alright fairies
 *   (_  \_/ -' ,_   who is ready
    * / ,/  V \//     to run some
 *   (_///\   /u       SPARQL??!
     *  \\/=o=|     *
  *     (/\ | |   *
     *    /_/_/        *
         |___)_)
```
