### PR TITLE
[ccEngine] cc.license dev2019 branch

### DIFF
--- a/cc/license/_lib/classes.py
+++ b/cc/license/_lib/classes.py
@@ -61,7 +61,7 @@ class License(object):
     def title(self, language='en'):
         if self._titles is None:
             self._titles = rdf_helper.get_titles(self.uri)
-        i18n_title = self._titles['i18n']
+        i18n_title = self._titles['x-i18n']
         return inverse_translate(i18n_title, locale_to_lower_upper(language))
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,36 @@
 from setuptools import setup, find_packages
 
-setup(name='cc.license',
-      version='0.14.25',
-      namespace_packages = ['cc',],
-      description="License selection based on ccREL-based metadata.",
-      classifiers=[],
-      keywords='',
-      author='Creative Commons',
-      author_email='software@creativecommons.org',
-      url='http://wiki.creativecommons.org/CcLicense',
-      license='MIT',
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      #package_data={'cc.license': ['*.xml', '*.txt']}, # doesn't work
-      zip_safe=False,
-      test_suite='nose.collector',
-      install_requires=[
-        'rdflib<3.0',
-        'cc.licenserdf',
-        'setuptools',
-        'nose',
-        'lxml',
-        'rdfadict',
-        'python-gettext<2.0',
-        'jinja2',
+setup(
+    name='cc.license',
+    description="License selection based on ccREL-based metadata.",
+    version='0.14.25',
+    url='http://wiki.creativecommons.org/CcLicense',
+    license='MIT',
+    author='Creative Commons',
+    author_email='software@creativecommons.org',
+
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    include_package_data=True,
+    zip_safe=False,
+    namespace_packages=['cc', ],
+    test_suite='nose.collector',
+
+    install_requires=[
         'cc.i18n',
-      ],
+        'cc.licenserdf',
+        'jinja2',
+        'lxml',
+        'nose',
+        'python-gettext<2.0',
+        'rdfadict',
+        'rdflib<3.0',
+        'setuptools'],
 
-      dependency_links = [
-        'https://github.com/creativecommons/cc.i18n/tarball/master#egg=cc.i18n',
-        'https://github.com/creativecommons/cc.licenserdf/tarball/master#egg=cc.licenserdf',
-      ],
+    dependency_links=[
+        'https://github.com/creativecommons/cc.i18n/tarball/'
+        'master#egg=cc.i18n',
+        'https://github.com/creativecommons/cc.licenserdf/tarball/'
+        'master#egg=cc.licenserdf'],
 
-      setup_requires=['setuptools-git',],
-      )
+    setup_requires=['setuptools-git', ],
+    )

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
         'jinja2',
         'lxml',
         'nose',
-        'python-gettext<2.0',
+        'python-gettext',
         'rdfadict',
-        'rdflib<3.0',
+        'rdflib',
         'setuptools'],
 
     dependency_links=[


### PR DESCRIPTION
## Description
- Correct ~~`i18n`~~ to `x-i18n` (a valid [RFC 5646][rfc5646] private use subtag)
- Fix `setup.py` dependencies for Debian GNU/Linux 10 (buster)

[rfc5646]: https://tools.ietf.org/html/rfc5646.html

## Tests
This was tested in staging, then [Test new.creativecommons.org as a pending replacement of creativecommons.org · Issue #1092](https://github.com/creativecommons/creativecommons.org/issues/1092).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
